### PR TITLE
Trim blobs in Sampler.posterior

### DIFF
--- a/pocomc/sampler.py
+++ b/pocomc/sampler.py
@@ -947,6 +947,8 @@ class Sampler:
             logl = logl[idx]
             logp = logp[idx]
             logw = logw[idx]
+            if return_blobs:
+                blobs = blobs[idx]
 
         if resample:
             if self.resample == 'mult':


### PR DESCRIPTION
If trim_importance weights is set in Sampler.posterior then the blobs are not currently trimmed, leading to them being a different size and misaligned with the samples.